### PR TITLE
Allowing proxy settings from the environment

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -70,6 +70,7 @@ func NewClientWithTLS(url string, tlsConfig *tls.Config) *Client {
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 			Transport: &http.Transport{
+				Proxy:           http.ProxyFromEnvironment,
 				TLSClientConfig: tlsConfig,
 			},
 			CheckRedirect: func(req *http.Request, via []*http.Request) error {


### PR DESCRIPTION
Same as for addedeffect. `NewClientWithTLS` is unfortunately used in the enforcer and will otherwise ignore proxy settings from the environment.