### PR TITLE
allowing proxy settings from the environment (#30)

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -70,6 +70,7 @@ func NewClientWithTLS(url string, tlsConfig *tls.Config) *Client {
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 			Transport: &http.Transport{
+				Proxy:           http.ProxyFromEnvironment,
 				TLSClientConfig: tlsConfig,
 			},
 			CheckRedirect: func(req *http.Request, via []*http.Request) error {


### PR DESCRIPTION
Backport for 3.11 which is used by 3.12 enforcer.