### PR TITLE
fix: remove duplicates when normalizing auth claims

### DIFF
--- a/client/utils.go
+++ b/client/utils.go
@@ -166,14 +166,21 @@ func NormalizeAuth(c *types.MidgardClaims) (claims []string) {
 		return
 	}
 
+	cache := map[string]struct{}{}
+
 	if c.Subject != "" {
-		claims = append(claims, "@auth:subject="+c.Subject)
+		cache["@auth:subject="+c.Subject] = struct{}{}
 	}
 
 	for key, value := range c.Data {
 		if value != "" {
-			claims = append(claims, "@auth:"+strings.ToLower(key)+"="+value)
+			cache["@auth:"+strings.ToLower(key)+"="+value] = struct{}{}
 		}
+	}
+
+	// remove duplicates
+	for key := range cache {
+		claims = append(claims, key)
 	}
 
 	sort.Strings(claims)

--- a/client/utils_test.go
+++ b/client/utils_test.go
@@ -108,6 +108,7 @@ func TestUtils_NormalizeAuth(t *testing.T) {
 		auth.Claims.Subject = "subject"
 		auth.Claims.Data["d1"] = "v1"
 		auth.Claims.Data["d2"] = "v2"
+		auth.Claims.Data["subject"] = "subject"
 
 		Convey("When I normalize it", func() {
 


### PR DESCRIPTION
The subject was sometimes redundant in the claims. This PR avoid duplicates if the entire claim string is already present.